### PR TITLE
Bump PHP to min 8.3

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -14,11 +14,7 @@ jobs:
       matrix:
         php:
           - 8.3
-          - 8.2
-          - 8.1
-          - 8.0
-          - 7.4
-          - 7.3
+          - 8.4
         composer:
           - 2
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,7 @@
     "description": "Interfaces that helps to describe extension",
     "type": "library",
     "require": {
-        "php": ">=7.3",
-        "myclabs/php-enum": "^1.7",
+        "php": ">=8.3",
         "league/flysystem": "^2.0",
         "ext-fileinfo": "*"
     },

--- a/src/Elements/BlockInterface.php
+++ b/src/Elements/BlockInterface.php
@@ -11,43 +11,31 @@ interface BlockInterface
 {
     /**
      * Gets block name
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Gets block description
-     *
-     * @return string
      */
     public function getDescription(): string;
 
     /**
      * Gets block template
-     *
-     * @return TemplateInterface|null
      */
     public function getTemplate(): ?TemplateInterface;
 
     /**
      * Gets callback to show block
-     *
-     * @return callable|null
      */
     public function getShowCallback(): ?callable;
 
     /**
      * Gets callback to edit block
-     *
-     * @return callable|null
      */
     public function getEditCallback(): ?callable;
 
     /**
      * Gets block options
-     *
-     * @return mixed
      */
-    public function getOptions();
+    public function getOptions(): mixed;
 }

--- a/src/Elements/CommentPlaceInterface.php
+++ b/src/Elements/CommentPlaceInterface.php
@@ -14,15 +14,11 @@ interface CommentPlaceInterface extends SupportsHooksInterface
 
     /**
      * Get name of place
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Link info when detecting a place
-     *
-     * @return InlineLinkInterface
      */
     public function getLink(): InlineLinkInterface;
 

--- a/src/Elements/CronJobInterface.php
+++ b/src/Elements/CronJobInterface.php
@@ -14,29 +14,21 @@ interface CronJobInterface
 
     /**
      * Gets name
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Is this cron job by default enabled?
-     *
-     * @return bool
      */
     public function isEnabled(): bool;
 
     /**
      * Gets cron expression when it will need to run another time
-     *
-     * @return CronExpression
      */
     public function getExpression(): CronExpression;
 
     /**
      * Gets action to be executed for this cron
-     *
-     * @return callable
      */
     public function getAction(): callable;
 

--- a/src/Elements/DirectLinkInterface.php
+++ b/src/Elements/DirectLinkInterface.php
@@ -12,8 +12,6 @@ interface DirectLinkInterface extends InlineLinkInterface
 
     /**
      * Gets URL
-     *
-     * @return string
      */
     public function getUrl(): string;
 

--- a/src/Elements/HookInterface.php
+++ b/src/Elements/HookInterface.php
@@ -11,16 +11,12 @@ interface HookInterface
 {
 
     /**
-     * GEts event name when hook should be executed
-     *
-     * @return string
+     * Gets event name when hook should be executed
      */
     public function getEventName(): string;
 
     /**
      * Returns action that should be executed for this hook
-     *
-     * @return callable
      */
     public function getAction(): callable;
 }

--- a/src/Elements/IconInterface.php
+++ b/src/Elements/IconInterface.php
@@ -14,15 +14,11 @@ interface IconInterface
 
     /**
      * Gets path to icon
-     *
-     * @return FileAttributes
      */
     public function getFile(): FileAttributes;
 
     /**
      * Gets icon category
-     *
-     * @return string
      */
     public function getCategory(): string;
 }

--- a/src/Elements/LinkInterface.php
+++ b/src/Elements/LinkInterface.php
@@ -14,15 +14,11 @@ interface LinkInterface
 
     /**
      * Gets URL where link is pointing
-     *
-     * @return string
      */
     public function getUrl(): string;
 
     /**
      * Gets link type
-     *
-     * @return LinkType
      */
     public function getType(): LinkType;
 

--- a/src/Elements/MemberInterface.php
+++ b/src/Elements/MemberInterface.php
@@ -14,22 +14,16 @@ interface MemberInterface
 
     /**
      * Gets member name
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Gets links to external resources
-     *
-     * @return LinkInterface[]
      */
     public function getLinks(): array;
 
     /**
      * Gets member roles
-     *
-     * @return MemberRole[]
      */
     public function getRoles(): array;
 }

--- a/src/Elements/MenuItemInterface.php
+++ b/src/Elements/MenuItemInterface.php
@@ -15,36 +15,26 @@ interface MenuItemInterface
 
     /**
      * Gets menu item title
-     *
-     * @return string
      */
     public function getTitle(): string;
 
     /**
      * Returns menu classes for this item
-     *
-     * @return string[]
      */
     public function getClass(): array;
 
     /**
      * Gets link for menu item
-     *
-     * @return InlineLinkInterface
      */
     public function getLink(): InlineLinkInterface;
 
     /**
      * Gets area type
-     *
-     * @return AreaType
      */
     public function getAreaType(): AreaType;
 
     /**
      * If any, menu item will require user to have specific roles to be able to shown
-     *
-     * @return string[]
      */
     public function needsRoles(): array;
 }

--- a/src/Elements/NotificationCategoryInterface.php
+++ b/src/Elements/NotificationCategoryInterface.php
@@ -12,29 +12,21 @@ interface NotificationCategoryInterface
 
     /**
      * Internal name for notification category
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Text displayed for user
-     *
-     * @return string
      */
     public function getTitle(): string;
 
     /**
      * Gets description for category
-     *
-     * @return string|null
      */
     public function getDescription(): ?string;
 
     /**
      * Gets paths from where this notification category subscription should be visible
-     *
-     * @return iterable|InlineLinkInterface[]
      */
     public function getSubscriptionPaths(): iterable;
 

--- a/src/Elements/NotificationEventInterface.php
+++ b/src/Elements/NotificationEventInterface.php
@@ -12,43 +12,33 @@ interface NotificationEventInterface
 
     /**
      * Gets notifications event internal name
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Gets notification category name for what this event only applies
-     *
-     * @return string
      */
     public function getCategory(): string;
 
     /**
      * Gets title to be shown for user notification selection
-     *
-     * @return string
      */
     public function getSelectionTitle(): string;
 
     /**
      * gets title when notification send
-     *
-     * @return string|callable
      */
-    public function getSendTitle();
+    public function getSendTitle(): string|callable;
 
     /**
      * Gets description when notification is send
-     *
-     * @return string|callable
      */
-    public function getSendDescription();
+    public function getSendDescription(): string|callable;
 
     /**
      * Gets extra data for this event
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getData(): array;
 

--- a/src/Elements/RelatedPackageInterface.php
+++ b/src/Elements/RelatedPackageInterface.php
@@ -2,8 +2,6 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Elements;
 
-use Imponeer\Contracts\ExtensionInfo\Enum\PackageRelationType;
-
 /**
  * Defines related package
  *
@@ -14,22 +12,16 @@ interface RelatedPackageInterface
 
     /**
      * Gets related package name
-     *
-     * @return string
      */
     public function getPackageName(): string;
 
     /**
      * Gets version constraint in composer style
-     *
-     * @return string
      */
     public function getVersionConstraint(): string;
 
     /**
      * If there is reason for it, get's it
-     *
-     * @return string
      */
     public function getReason(): string;
 

--- a/src/Elements/RouteLinkInterface.php
+++ b/src/Elements/RouteLinkInterface.php
@@ -12,15 +12,11 @@ interface RouteLinkInterface extends InlineLinkInterface
 
     /**
      * Route name
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Gets params for route link
-     *
-     * @return array
      */
     public function getParams(): array;
 }

--- a/src/Elements/TemplateInterface.php
+++ b/src/Elements/TemplateInterface.php
@@ -14,15 +14,11 @@ interface TemplateInterface
 
     /**
      * Get reference to template file
-     *
-     * @return FileAttributes
      */
     public function getFile(): FileAttributes;
 
     /**
      * Gets template description
-     *
-     * @return string
      */
     public function getDescription(): string;
 }

--- a/src/Elements/UserConfigItemInterface.php
+++ b/src/Elements/UserConfigItemInterface.php
@@ -12,43 +12,31 @@ interface UserConfigItemInterface
 
     /**
      * Configuration item name
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Gets title
-     *
-     * @return string
      */
     public function getTitle(): string;
 
     /**
      * Gets description
-     *
-     * @return string|null
      */
     public function getDescription(): ?string;
 
     /**
      * Gets default value
-     *
-     * @return mixed
      */
-    public function getDefaultValue();
+    public function getDefaultValue(): mixed;
 
     /**
      * Gets short description how to display on form
-     *
-     * @return string|null
      */
     public function getFormType(): ?string;
 
     /**
      * Gets value type of this config item (how it should be processed?)
-     *
-     * @return string
      */
     public function getValueType(): ?string;
 }

--- a/src/Enum/AreaType.php
+++ b/src/Enum/AreaType.php
@@ -2,27 +2,22 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Defines area type
  *
  * @package Imponeer\Contracts\ExtensionInfo\Enum
- *
- * @method static AreaType USER_SIDE()
- * @method static AreaType ADMIN_SIDE()
  */
-class AreaType extends Enum
+enum AreaType: int
 {
 
     /**
      * Screenshot is for user side
      */
-    protected const USER_SIDE = 0;
+    case USER_SIDE = 0;
 
     /**
      * Screenshot is for admin side
      */
-    protected const ADMIN_SIDE = 1;
+    case ADMIN_SIDE = 1;
 
 }

--- a/src/Enum/ExtensionState.php
+++ b/src/Enum/ExtensionState.php
@@ -2,32 +2,26 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Defines package State enum
  *
  * @package Imponeer\Contracts\ExtensionInfo\Enum
- *
- * @method static ExtensionState ABANDONED()
- * @method static ExtensionState ACTIVE()
- * @method static ExtensionState UNKNOWN()
  */
-class ExtensionState extends Enum
+enum ExtensionState: int
 {
 
     /**
      * This mean package is abandoned
      */
-    private const ABANDONED = 2;
+    case ABANDONED = 2;
 
     /**
      * This mean package still receives updated
      */
-    private const ACTIVE = 1;
+    case ACTIVE = 1;
 
     /**
      * This means that package has unknown state (missing some information)
      */
-    private const UNKNOWN = 0;
+    case UNKNOWN = 0;
 }

--- a/src/Enum/ExtensionType.php
+++ b/src/Enum/ExtensionType.php
@@ -2,44 +2,36 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Defines extension type enum
  *
  * @package Imponeer\Contracts\ExtensionInfo\Enum
- *
- * @method static ExtensionType UNKNOWN()
- * @method static ExtensionType MODULE()
- * @method static ExtensionType THEME()
- * @method static ExtensionType TRANSLATION()
- * @method static ExtensionType LIBRARY()
  */
-class ExtensionType extends Enum
+enum ExtensionType: int
 {
 
     /**
      * This means that package type can't be determined
      */
-    private const UNKNOWN = 0;
+    case UNKNOWN = 0;
 
     /**
      * This means package is module
      */
-    private const MODULE = 1;
+    case MODULE = 1;
 
     /**
      * This means package is a theme
      */
-    private const THEME = 2;
+    case THEME = 2;
 
     /**
      * This means package is translation
      */
-    private const TRANSLATION = 3;
+    case TRANSLATION = 3;
 
     /**
      * This means package is some library
      */
-    private const LIBRARY = 4;
+    case LIBRARY = 4;
 }

--- a/src/Enum/LinkType.php
+++ b/src/Enum/LinkType.php
@@ -2,87 +2,72 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * LinkType enum
  *
  * @package Imponeer\Contracts\ExtensionInfo\Enum
- *
- * @method static LinkType EMAIL()
- * @method static LinkType ISSUES_TRACKER()
- * @method static LinkType FORUM()
- * @method static LinkType HOMEPAGE()
- * @method static LinkType WIKI()
- * @method static LinkType IRC()
- * @method static LinkType SOURCE_CODE_PAGE()
- * @method static LinkType VERSION_CONTROL()
- * @method static LinkType DOCUMENTATION()
- * @method static LinkType RSS()
- * @method static LinkType WEB_CHAT()
- * @method static LinkType FUNDING_PAGE()
  */
-class LinkType extends Enum
+enum LinkType: int
 {
 
     /**
      * Link is email
      */
-    private const EMAIL = 1;
+    case EMAIL = 1;
 
     /**
      * Link points to issues tracker
      */
-    private const ISSUES_TRACKER = 2;
+    case ISSUES_TRACKER = 2;
 
     /**
      * Link points to forum
      */
-    private const FORUM = 3;
+    case FORUM = 3;
 
     /**
      * Link points to homepage
      */
-    private const HOMEPAGE = 4;
+    case HOMEPAGE = 4;
 
     /**
      * Link points to wiki site
      */
-    private const WIKI = 5;
+    case WIKI = 5;
 
     /**
      * Link points to IRC chat
      */
-    private const IRC = 6;
+    case IRC = 6;
 
     /**
      * Link points to source code page
      */
-    private const SOURCE_CODE_PAGE = 7;
+    case SOURCE_CODE_PAGE = 7;
 
     /**
      * Link points to version control data
      */
-    private const VERSION_CONTROL = 8;
+    case VERSION_CONTROL = 8;
 
     /**
      * Links points to documentation
      */
-    private const DOCUMENTATION = 9;
+    case DOCUMENTATION = 9;
 
     /**
      * Link points to RSS
      */
-    private const RSS = 10;
+    case RSS = 10;
 
     /**
      * Link points to web chat
      */
-    private const WEB_CHAT = 11;
+    case WEB_CHAT = 11;
 
     /**
      * Link points to funding page
      */
-    private const FUNDING_PAGE = 12;
+    case FUNDING_PAGE = 12;
 
 }

--- a/src/Enum/MemberRole.php
+++ b/src/Enum/MemberRole.php
@@ -2,56 +2,46 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Member role enum
  *
  * @package Imponeer\Contracts\ExtensionInfo\Enum
- *
- * @method static MemberRole UNKNOWN()
- * @method static MemberRole DEVELOPER()
- * @method static MemberRole DESIGNER()
- * @method static MemberRole MANAGER()
- * @method static MemberRole TESTER()
- * @method static MemberRole DOCUMENTATION_WRITER()
- * @method static MemberRole TRANSLATOR()
  */
-class MemberRole extends Enum
+enum MemberRole: int
 {
 
     /**
      * Team member has unknown role
      */
-    private const UNKNOWN = 0;
+    case UNKNOWN = 0;
 
     /**
      * Team member has developer role
      */
-    private const DEVELOPER = 1;
+    case DEVELOPER = 1;
 
     /**
      * Team member is designer
      */
-    private const DESIGNER = 2;
+    case DESIGNER = 2;
 
     /**
      * Team member is manager
      */
-    private const MANAGER = 3;
+    case MANAGER = 3;
 
     /**
      * Team member is tester
      */
-    private const TESTER = 4;
+    case TESTER = 4;
 
     /**
      * Team member is documentation writer
      */
-    private const DOCUMENTATION_WRITER = 5;
+    case DOCUMENTATION_WRITER = 5;
 
     /**
      * Team member is translator
      */
-    private const TRANSLATOR = 6;
+    case TRANSLATOR = 6;
 }

--- a/src/Enum/ScreenshotType.php
+++ b/src/Enum/ScreenshotType.php
@@ -2,27 +2,22 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Enum;
 
-use MyCLabs\Enum\Enum;
-
 /**
  * Defines screenshot type
  *
  * @package Imponeer\Contracts\ExtensionInfo\Enum
- *
- * @method static ScreenshotType USER_SIDE()
- * @method static ScreenshotType ADMIN_SIDE()
  */
-class ScreenshotType extends Enum
+enum ScreenshotType: int
 {
 
     /**
      * Screenshot is for user side
      */
-    private const USER_SIDE = 0;
+    case USER_SIDE = 0;
 
     /**
      * Screenshot is for admin side
      */
-    private const ADMIN_SIDE = 1;
+    case ADMIN_SIDE = 1;
 
 }

--- a/src/Exceptions/UnsupportedExtensionException.php
+++ b/src/Exceptions/UnsupportedExtensionException.php
@@ -20,7 +20,7 @@ class UnsupportedExtensionException extends Exception
      * @param int $code Error code
      * @param Throwable|null $previous Previous exception
      */
-    public function __construct($name, $code = 0, ?Throwable $previous = null)
+    public function __construct(string $name, int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($name . ' extension for this factory is not supported', $code, $previous);
     }

--- a/src/ExtensionInfoInterface.php
+++ b/src/ExtensionInfoInterface.php
@@ -20,99 +20,71 @@ interface ExtensionInfoInterface
 
     /**
      * Gets extension type
-     *
-     * @return ExtensionType
      */
     public function getType(): ExtensionType;
 
     /**
      * Gets name of CMS or anything other that this extension is made for
-     *
-     * @return string
      */
     public function getWhatFor(): string;
 
     /**
      * Gets extension name
-     *
-     * @return string
      */
     public function getName(): string;
 
     /**
      * Gets path where this extension is located
-     *
-     * @return string
      */
     public function getPath(): string;
 
     /**
      * Get SPDX license name or "proprietary" for commercial
-     *
-     * @return string[]
      */
     public function getLicense(): array;
 
     /**
      * Gets extension description
-     *
-     * @return string
      */
     public function getDescription(): string;
 
     /**
      * Gets license version
-     *
-     * @return string
      */
     public function getVersion(): string;
 
     /**
      * Gets release date
-     *
-     * @return DateTime|null
      */
     public function getReleaseDate(): ?DateTime;
 
     /**
      * Gets links to external resources
-     *
-     * @return LinkInterface[]
      */
     public function getLinks(): array;
 
     /**
      * State of the extension
-     *
-     * @return ExtensionState
      */
     public function getState(): ExtensionState;
 
     /**
      * Gets Filesystem to current instance of extension
-     *
-     * @return Filesystem|null
      */
     public function getFiles(): ?Filesystem;
 
     /**
      * Gets team members of this extension
-     *
-     * @return MemberInterface[]
      */
     public function getTeamMembers(): array;
 
     /**
      * Gets required packages
-     *
-     * @return iterable|RelatedPackageInterface[]
      */
     public function getRequiredPackages(): iterable;
 
     /**
      * Gets suggested packages
-     *
-     * @return iterable|RelatedPackageInterface[]
      */
     public function getSuggestedPackages(): iterable;
 }

--- a/src/Factory/FromPathFactoryInterface.php
+++ b/src/Factory/FromPathFactoryInterface.php
@@ -18,8 +18,6 @@ interface FromPathFactoryInterface
      *
      * @param string $path
      *
-     * @return ExtensionInfoInterface
-     *
      * @throws UnsupportedExtensionException
      */
     public function createFromPath(string $path): ExtensionInfoInterface;
@@ -28,8 +26,6 @@ interface FromPathFactoryInterface
      * Checks if info factory supports such path
      *
      * @param string $path Path to check if this info reader supports such path
-     *
-     * @return bool
      */
     public function supportsPath(string $path): bool;
 }

--- a/src/Features/SupportReplacementsPackages.php
+++ b/src/Features/SupportReplacementsPackages.php
@@ -15,7 +15,7 @@ interface SupportReplacementsPackages
     /**
      * Gets packages list that this extension replaces
      *
-     * @return iterable|RelatedPackageInterface[]
+     * @return iterable<RelatedPackageInterface>
      */
     public function getReplaces(): iterable;
 

--- a/src/Features/SupportsAssetsInterface.php
+++ b/src/Features/SupportsAssetsInterface.php
@@ -15,7 +15,7 @@ interface SupportsAssetsInterface
     /**
      * Get files attributes collection for assets from package
      *
-     * @return iterable|FileAttributes[]
+     * @return iterable<FileAttributes>
      */
     public function getAssets(): iterable;
 

--- a/src/Features/SupportsBlocksInterface.php
+++ b/src/Features/SupportsBlocksInterface.php
@@ -15,7 +15,7 @@ interface SupportsBlocksInterface
     /**
      * Gets blocks data
      *
-     * @return BlockInterface[]
+     * @return iterable<BlockInterface>
      */
     public function getBlocks(): iterable;
 

--- a/src/Features/SupportsCommentsInterface.php
+++ b/src/Features/SupportsCommentsInterface.php
@@ -15,7 +15,7 @@ interface SupportsCommentsInterface
     /**
      * Gets places where comments can be
      *
-     * @return iterable|CommentPlaceInterface[]
+     * @return iterable<CommentPlaceInterface>
      */
     public function getCommentsPlaces(): iterable;
 

--- a/src/Features/SupportsConflictedPackages.php
+++ b/src/Features/SupportsConflictedPackages.php
@@ -15,7 +15,7 @@ interface SupportsConflictedPackages
     /**
      * Gets packages with whom extension conflicts
      *
-     * @return iterable|RelatedPackageInterface[]
+     * @return iterable<RelatedPackageInterface>
      */
     public function getConflictedPackages(): iterable;
 

--- a/src/Features/SupportsCronJobsInterface.php
+++ b/src/Features/SupportsCronJobsInterface.php
@@ -2,6 +2,8 @@
 
 namespace Imponeer\Contracts\ExtensionInfo\Features;
 
+use Imponeer\Contracts\ExtensionInfo\Elements\CronJobInterface;
+
 /**
  * If extension can have cron jobs this interface must be implemented too
  *
@@ -13,7 +15,7 @@ interface SupportsCronJobsInterface
     /**
      * Gets cron jobs list
      *
-     * @return iterable
+     * @return iterable<CronJobInterface>
      */
     public function getCronJobs(): iterable;
 

--- a/src/Features/SupportsEntitiesClassesInterface.php
+++ b/src/Features/SupportsEntitiesClassesInterface.php
@@ -16,8 +16,6 @@ interface SupportsEntitiesClassesInterface
     /**
      * If tables are automatically created from entities classes or models, this method should return reference to such
      * classes descriptions
-     *
-     * @return iterable|ReflectionClass[]
      */
     public function getEntitiesClasses(): iterable;
 

--- a/src/Features/SupportsHooksInterface.php
+++ b/src/Features/SupportsHooksInterface.php
@@ -15,7 +15,7 @@ interface SupportsHooksInterface
     /**
      * Returns collection of supported hooks
      *
-     * @return iterable|HookInterface[]
+     * @return iterable<HookInterface>
      */
     public function getHooks(): iterable;
 

--- a/src/Features/SupportsIconsInterface.php
+++ b/src/Features/SupportsIconsInterface.php
@@ -15,7 +15,7 @@ interface SupportsIconsInterface
     /**
      * Gets icons
      *
-     * @return iterable|IconInterface[]
+     * @return iterable<IconInterface>
      */
     public function getIcons(): iterable;
 

--- a/src/Features/SupportsMenuItemsInterface.php
+++ b/src/Features/SupportsMenuItemsInterface.php
@@ -14,8 +14,6 @@ interface SupportsMenuItemsInterface
 
     /**
      * Gets menu items
-     *
-     * @return iterable|MenuItemInterface[]
      */
     public function getMenuItems(): iterable;
 

--- a/src/Features/SupportsMigrationsInterface.php
+++ b/src/Features/SupportsMigrationsInterface.php
@@ -13,14 +13,12 @@ interface SupportsMigrationsInterface
     /**
      * Gets paths where migration paths are available
      *
-     * @return iterable|string[]
+     * @return iterable<string>
      */
     public function getMigrationsPaths(): iterable;
 
     /**
      * Gets name of provider who deals with extensions migrations (f.e. phinx, phoenix, yii-migrations...)
-     *
-     * @return string
      */
     public function getMigrationsProvider(): string;
 

--- a/src/Features/SupportsNotificationsInterface.php
+++ b/src/Features/SupportsNotificationsInterface.php
@@ -15,15 +15,11 @@ interface SupportsNotificationsInterface
 
     /**
      * Gets notifications categories
-     *
-     * @return iterable|NotificationCategoryInterface[]
      */
     public function getNotificationsCategories(): iterable;
 
     /**
      * Gets info about events that triggers notifications
-     *
-     * @return iterable|NotificationEventInterface[]
      */
     public function getNotificationsEvents(): iterable;
 

--- a/src/Features/SupportsTablesInterface.php
+++ b/src/Features/SupportsTablesInterface.php
@@ -15,7 +15,7 @@ interface SupportsTablesInterface
     /**
      * Gets tables names that are managed by this extension
      *
-     * @return iterable|TableInterface[]
+     * @return iterable<TableInterface>
      */
     public function getTables(): iterable;
 

--- a/src/Features/SupportsTemplatesInterface.php
+++ b/src/Features/SupportsTemplatesInterface.php
@@ -15,7 +15,7 @@ interface SupportsTemplatesInterface
     /**
      * Returns templates info
      *
-     * @return iterable|TemplateInterface[]
+     * @return iterable<TemplateInterface>
      */
     public function getTemplates(): iterable;
 

--- a/src/Features/SupportsUserConfigItemsInterface.php
+++ b/src/Features/SupportsUserConfigItemsInterface.php
@@ -15,7 +15,7 @@ interface SupportsUserConfigItemsInterface
     /**
      * Gets user config items
      *
-     * @return iterable|UserConfigItemInterface[]
+     * @return iterable<UserConfigItemInterface>
      */
     public function getUserConfigItems(): iterable;
 


### PR DESCRIPTION
Resolves #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated support for PHP 8.3 and 8.4; older PHP versions are no longer supported.
  
* **Refactor**
  * Replaced third-party enum library with native PHP enums for improved performance and compatibility.
  * Enhanced type safety by adding or updating return type declarations and parameter types in several interfaces and classes.
  * Improved code documentation by refining or removing redundant PHPDoc annotations for better clarity and maintainability.

* **Chores**
  * Removed an unused dependency from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->